### PR TITLE
fix: Specify correct TLS protocol for SSLContext, fix connecting

### DIFF
--- a/OneLauncher/OneLauncherUtils.py
+++ b/OneLauncher/OneLauncherUtils.py
@@ -73,7 +73,7 @@ def checkForCertificates(logger):
         certfile = None
 
     global sslContext
-    sslContext = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+    sslContext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     sslContext.set_ciphers('DEFAULT@SECLEVEL=1')
     if certfile:
         sslContext.verify_mode = ssl.CERT_REQUIRED


### PR DESCRIPTION
Standing Stones servers now use TLSv1_2 instead of TLSv1.
Since OpenSSL has deprecated all version specific protocols specify
TLS_CLIENT instead as suggested since Python 3.6.

Resolves #44.